### PR TITLE
Fixes `merge is not a function` error in > RN 0.10.1

### DIFF
--- a/recorder.ios.js
+++ b/recorder.ios.js
@@ -7,6 +7,7 @@ var {
   View,
   merge
 } = React;
+merge = merge || require('merge');
 
 /******* ENUM **********/
 


### PR DESCRIPTION
Backwards-compatible fix for `merge is not a function` error.  (#10)
