### PR TITLE
merging into `this.props` no longer works in latest React Native

### DIFF
--- a/recorder.ios.js
+++ b/recorder.ios.js
@@ -128,7 +128,7 @@ var Recorder = React.createClass({
 
     },this.props.config);
 
-    var nativeProps = merge(this.props, {
+    var nativeProps = merge({}, this.props, {
       config: config,
       device: this.props.device || "front"
     });


### PR DESCRIPTION
simple fix to merge into new `nativeProps` object.
