### PR TITLE
Updated directory name in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Based on this awesome library [SCRecorder](https://github.com/rFlex/SCRecorder).
 
 1. `npm install react-native-screcorder@latest --save`
 2. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
-3. Go to `node_modules` ➜ `react-native-recorder` and add `RNRecorder.xcodeproj`
+3. Go to `node_modules` ➜ `react-native-screcorder` and add `RNRecorder.xcodeproj`
 4. In XCode, in the project navigator, select your project. Add `libRNRecorder.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 5. Click `RNRecorder.xcodeproj` in the project navigator and go the `Build Settings` tab. Make sure 'All' is toggled on (instead of 'Basic'). Look for `Header Search Paths` and make sure it contains both `$(SRCROOT)/../react-native/React` and `$(SRCROOT)/../../React` - mark both as `recursive`.
 5. Run your project (`Cmd+R`)


### PR DESCRIPTION
Using `npm install` creates a directory called `react-native-screcorder`, rather than `react-native-recorder`